### PR TITLE
Optimize AI quota scripts: model lookup and smaller az output

### DIFF
--- a/scripts/listAIQuotas.ps1
+++ b/scripts/listAIQuotas.ps1
@@ -45,8 +45,19 @@ function Get-Quotas() {
     foreach ($location in $locations) {
         Write-Host "Fetching quotas for location $location..."
         try {
-            $usages = (az cognitiveservices usage list --location $location) | ConvertFrom-Json
-            $models = (az cognitiveservices model list --location $location) | ConvertFrom-Json
+            $usages = (az cognitiveservices usage list --location $location --query '[].{name: name.value, currentValue: currentValue, limit: limit}' ) | ConvertFrom-Json
+            $models = (az cognitiveservices model list --location $location --query '[].{name: model.name, sku: model.skus[0].name, kind: kind, version: model.version}' ) | ConvertFrom-Json
+
+            # Build a lookup map of models keyed by kind.sku.name -> array of versions for fast lookups
+            $modelLookup = @{}
+            foreach ($m in $models) {
+                $sku = ($m.sku)
+                $key = "$($m.kind).$($sku).$($m.name)"
+                if (-not $modelLookup.ContainsKey($key)) { $modelLookup[$key] = @() }
+                if (-not ($modelLookup[$key] -contains $m.version)) {
+                    $modelLookup[$key] += $m.version
+                }
+            }
         }
         catch {
             Write-Host "Failed to fetch quotas for location $location : $_"
@@ -61,14 +72,13 @@ function Get-Quotas() {
                 continue
             }
 
-            # Find the candidate model in the list of models and get the available versions
+            # Find the candidate model versions quickly using the pre-built lookup
             $available_versions = @()
-            $models | ForEach-Object {
-                $model = $_
-                $skuMatch = $model.model.skus | Where-Object { $_.name -eq $candidate.sku }
-                if ($model.model.name -eq $candidate.name -and $model.kind -eq $candidate.kind -and $skuMatch) {
-                    if ($candidate.versions -contains '*' -or $candidate.versions -contains $model.model.version) {
-                        $available_versions += $model.model.version
+            $lookupKey = "$($candidate.kind).$($candidate.sku).$($candidate.name)"
+            if ($modelLookup.ContainsKey($lookupKey)) {
+                foreach ($ver in $modelLookup[$lookupKey]) {
+                    if ($candidate.versions -contains '*' -or $candidate.versions -contains $ver) {
+                        $available_versions += $ver
                     }
                 }
             }

--- a/scripts/listAIQuotas.sh
+++ b/scripts/listAIQuotas.sh
@@ -22,6 +22,26 @@ get_quotas() {
         
         local usages=$(az cognitiveservices usage list --location $location --query "[].{name: name.value, currentValue: currentValue, limit: limit}" -o tsv)
         local models=$(az cognitiveservices model list --location $location --query "[].{name: model.name, sku: model.skus[0].name, kind: kind, version: model.version}" -o tsv)
+
+        # Build associative array: key=kind.sku.name value=comma-separated-versions
+        declare -A model_map
+        IFS=$'\n'
+        for m in $models; do
+            model_name=$(echo $m | cut -f1)
+            sku=$(echo $m | cut -f2)
+            kind=$(echo $m | cut -f3)
+            version=$(echo $m | cut -f4)
+            key="$kind.$sku.$model_name"
+            if [ -z "${model_map[$key]:-}" ]; then
+                model_map[$key]="$version"
+            else
+                # append if not present
+                if ! echo ",${model_map[$key]}", | grep -q ",$version,"; then
+                    model_map[$key]="${model_map[$key]},$version"
+                fi
+            fi
+        done
+        unset IFS
         
         IFS=$'\n'
         for usage in $usages; do
@@ -44,19 +64,18 @@ get_quotas() {
                     continue
                 fi
                 
-                # Find the candidate model in the list of models and get the available versions
+                # Lookup available versions from model_map
                 available_versions=()
-                for model in $models; do
-                    local model_name=$(echo $model | cut -f1)
-                    local sku=$(echo $model | cut -f2)
-                    local kind=$(echo $model | cut -f3)
-                    local version=$(echo $model | cut -f4)
-                    if [[  $model_fullname == "$kind.$sku.$model_name" ]]; then
+                key="$model_fullname"
+                versions_str="${model_map[$key]:-}"
+                if [ -n "$versions_str" ]; then
+                    IFS="," read -ra all_versions <<< "$versions_str"
+                    for version in "${all_versions[@]}"; do
                         if [[ "$versions" == *"*"* ]] || echo "$versions" | grep -q -w "$version"; then
                             available_versions+=("$version")
                         fi
-                    fi
-                done
+                    done
+                fi
                 
                 # Skip if no available versions
                 if [ ${#available_versions[@]} -eq 0 ]; then


### PR DESCRIPTION
Why
These scripts were scanning the full model list for every usage row across regions, causing O(usages * models) work and extra JSON parsing. That became expensive when many locations or models are present.

What changed
- Build a per-location model lookup (map) once, then lookup versions per usage entry.
- Limit az CLI JSON/TSV output to only needed fields via --query to reduce parsing and bandwidth.
- Applied the same approach to both PowerShell and Bash scripts.

Why this helps
Reduces CPU and parsing work from O(usages * models) to O(models + usages), lowers network payloads, and avoids repeated allocations inside inner loops. Wall-clock time should drop substantially for multi-region runs.

Notes and follow-ups
- Behavior is unchanged; script outputs remain the same. Recommend adding parallel region queries and retry/backoff for az calls as a next improvement.

Files changed
- scripts/listAIQuotas.ps1
- scripts/listAIQuotas.sh

N/A for issue closing.